### PR TITLE
Bugfixes

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,18 +13,23 @@ class ChatterApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       title: 'Chatter',
-      
-      theme: ThemeData(textTheme: TextTheme(body1: TextStyle(fontFamily: 'Poppins'),),),
+
+      theme: ThemeData(
+        textTheme: TextTheme(
+          bodyText1: TextStyle(
+            fontFamily: 'Poppins',
+          ),
+        ),
+      ),
       // home: ChatterHome(),
       initialRoute: '/',
       routes: {
-        '/':(context)=>ChatterHome(),
-        '/login':(context)=>ChatterLogin(),
-        '/signup':(context)=>ChatterSignUp(),
-        '/chat':(context)=>ChatterScreen(),
+        '/': (context) => ChatterHome(),
+        '/login': (context) => ChatterLogin(),
+        '/signup': (context) => ChatterSignUp(),
+        '/chat': (context) => ChatterScreen(),
         // '/chats':(context)=>ChatterScreen()
       },
     );
   }
 }
-

--- a/lib/pages/chat.dart
+++ b/lib/pages/chat.dart
@@ -63,7 +63,7 @@ class _ChatScreenState extends State<ChatScreen> {
                       decoration: kMessageTextFieldDecoration,
                     ),
                   ),
-                  FlatButton(
+                  TextButton(
                     onPressed: () {
                       //Implement send functionality.
                     },


### PR DESCRIPTION
# Description

Hi @ishandeveloper I fixed the following issues:

1.
> Error: No named parameter with the name 'body1'.

**Causes:**
The named parameter is `bodyText1` and not `body1` so that's what was causing the error.

```diff
 textTheme: TextTheme(
-          body1: TextStyle(
               fontFamily: 'Poppins',
           ),
 ),

 textTheme: TextTheme(
+          bodyText1: TextStyle(
                fontFamily: 'Poppins',
           ),
 ),
```

Fixes #7

2.
> 'FlatButton' is deprecated and shouldn't be used. Use TextButton instead. See the migration guide in flutter.dev/go/material-button-migration-guide). This feature was deprecated after v1.26.0-18.0.pre...

Soluction:

> Use TextButton instead

That's what I did.

```diff
- FlatButton(
      onPressed: () {
      //Implement send functionality.
   },

+ TextButton(
       onPressed: () {
                      //Implement send functionality.
       },
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] Any dependent changes have been merged and published in downstream modules

Hope this helps, thanks.
